### PR TITLE
Use cached git lfs checkout and fix failing autogen in windows

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -220,10 +220,8 @@ jobs:
       contents: read
       packages: write
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          lfs: true
+      - name: Checkout repository with cached git lfs
+        uses: nschloe/action-cached-lfs-checkout@v1
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -255,10 +253,8 @@ jobs:
     env:
       PORT: ${{ vars.PORT }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          lfs: true
+      - name: Checkout repository with cached git lfs
+        uses: nschloe/action-cached-lfs-checkout@v1
       - uses: actions/setup-node@v4
         with:
           node-version: 20
@@ -430,9 +426,8 @@ jobs:
       STRIPE_WEBHOOK_SECRET: ${{ github.ref_name == 'main' && secrets.PROD_STRIPE_WEBHOOK_SECRET || secrets.STAGING_STRIPE_WEBHOOK_SECRET }}
       SSH_KEY: ${{ github.ref_name == 'main' && secrets.PROD_SSH_KEY || secrets.STAGING_SSH_KEY }}
     steps:
-      - uses: actions/checkout@v3
-        with:
-          lfs: true
+      - name: Checkout repository with cached git lfs
+        uses: nschloe/action-cached-lfs-checkout@v1
       # This is to fix GIT not liking owner of the checkout dir - https://github.com/actions/runner/issues/2033#issuecomment-1204205989
       - run: chown -R $(id -u):$(id -g) $PWD
 
@@ -465,10 +460,8 @@ jobs:
       REACT_APP_CUSTOMER_PORTAL_LINK: ${{ github.ref_name == 'main' && vars.PROD_REACT_APP_CUSTOMER_PORTAL_LINK || vars.STAGING_REACT_APP_CUSTOMER_PORTAL_LINK }}
       REACT_APP_API_URL: ${{ github.ref_name == 'main' && vars.PROD_REACT_APP_API_URL || vars.STAGING_REACT_APP_API_URL }}
     steps:
-      - name: Checkout repository
-        uses: actions/checkout@v4
-        with:
-          lfs: true
+      - name: Checkout repository with cached git lfs
+        uses: nschloe/action-cached-lfs-checkout@v1
       - uses: actions/setup-node@v4
         with:
           node-version: 20

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -162,6 +162,7 @@ jobs:
       AZURE_GPT4_MODEL: ${{ secrets.STAGING_AZURE_GPT4_MODEL }}
       AZURE_GPT35_MODEL: ${{ secrets.STAGING_AZURE_GPT35_MODEL }}
       AZURE_OPENAI_API_KEY: ${{ secrets.STAGING_AZURE_OPENAI_API_KEY }}
+      AUTOGEN_USE_DOCKER: False
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python


### PR DESCRIPTION
# Description

Windows autogen fix has been already used for macos here - https://github.com/airtai/fastagency/blob/7882108ca264c19c325a1d25a70f271ab1adbd61/.github/workflows/test.yaml#L137
Using cached git lfs checkout in order to save bandwidth - https://github.com/actions/checkout/issues/165#issuecomment-940225299

Fixes #209, #211

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
