### PR TITLE
Add create_autogen method to BingAPIKey

### DIFF
--- a/fastagency/models/agents/web_surfer.py
+++ b/fastagency/models/agents/web_surfer.py
@@ -18,6 +18,13 @@ from .base import AgentBaseModel, llm_type_refs
 class BingAPIKey(Model):
     api_key: Annotated[str, Field(description="The API Key from OpenAI")]
 
+    @classmethod
+    def create_autogen(cls, model_id: UUID, user_id: UUID) -> str:
+        my_model_dict = syncify(find_model_using_raw)(model_id, user_id)
+        my_model = cls(**my_model_dict["json_str"])
+
+        return my_model.api_key
+
 
 BingAPIKeyRef: TypeAlias = BingAPIKey.get_reference_model()  # type: ignore[valid-type]
 


### PR DESCRIPTION
# Description

This was accidentally missed out while writing create_autogen methods for all the classes. Adding it now. 

Fixes #210 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
