### PR TITLE
Add AskingMessage class to mark messages that expect response

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -47,7 +47,7 @@ repos:
         name: Build docs
         entry: "scripts/build-docs-pre-commit.sh"
         language: python
-        language_version: python3.10
+        #language_version: python3.10
         files: ^docs
         require_serial: true
         verbose: true

--- a/fastagency/core/base.py
+++ b/fastagency/core/base.py
@@ -91,6 +91,13 @@ class IOMessage(ABC):  # noqa: B024  # `IOMessage` is an abstract base class, bu
         return retval
 
 
+# message type that asks user something
+
+
+@dataclass
+class AskingMessage(IOMessage): ...
+
+
 # type of output messages
 @dataclass
 class TextMessage(IOMessage):
@@ -118,14 +125,14 @@ class FunctionCallExecution(IOMessage):
 
 # types of input messages
 @dataclass
-class TextInput(IOMessage):
+class TextInput(AskingMessage):
     prompt: Optional[str] = None
     suggestions: List[str] = field(default_factory=list)
     password: bool = False
 
 
 @dataclass
-class MultipleChoice(IOMessage):
+class MultipleChoice(AskingMessage):
     prompt: Optional[str] = None
     choices: List[str] = field(default_factory=list)
     default: Optional[str] = None


### PR DESCRIPTION
It would be handy to be able to detect IOMessages that expect response from the user. one possible way would be for all of them to inherit from AskingMessage marker class.