### PR TITLE
Fix crashing when human_input_mode is not set to NEVER

### DIFF
--- a/fastagency/core/base.py
+++ b/fastagency/core/base.py
@@ -125,6 +125,7 @@ class FunctionCallExecution(IOMessage):
     function_name: Optional[str] = None
     call_id: Optional[str] = None
     retval: Any = None
+    body: Optional[str] = None
 
 
 # types of input messages


### PR DESCRIPTION
# Description

Please include a summary of the change and specify which issue is being addressed. Additionally, provide relevant motivation and context.

Fixes #113 

## Type of change

Please delete options that are not relevant.

- [ ] Documentation (typos, code examples, or any documentation updates)
- [ ] Bug fix (a non-breaking change that resolves an issue)
- [ ] New feature (a non-breaking change that adds functionality)
- [ ] Breaking change (a fix or feature that would disrupt existing functionality)
- [ ] This change requires a documentation update

## Checklist

- [ ] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [ ] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [ ] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [ ] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [ ] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
