### PR TITLE
Set concurrency in workflows to run one workflow at a time for one branch

### DIFF
--- a/.github/workflows/pipeline.yaml
+++ b/.github/workflows/pipeline.yaml
@@ -11,6 +11,10 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
 jobs:
   static-analysis:
     strategy:


### PR DESCRIPTION
# Description

When we push often to a branch then there are so many workflows running for same branch in parallel. This consumes more of our resources. This change runs only one workflow at a time for a branch. When new code is pushed existing running workflow is cancelled and new workflow as usual runs for newly pushed code. 

Change taken from faststream - https://github.com/airtai/faststream/blob/main/.github/workflows/pr_tests.yaml#L19-L21. 

Fixes #168 

