### PR TITLE
Fix parsing error in Autogen CurrentMessage

### DIFF
--- a/fastagency/runtime/autogen/base.py
+++ b/fastagency/runtime/autogen/base.py
@@ -44,7 +44,7 @@ _patterns = {
         "^\\x1b\\[32m\\*\\*\\*\\*\\* Suggested tool call \\((call_[a-zA-Z0-9]+)\\): ([a-zA-Z0-9_]+) \\*\\*\\*\\*\\*\\x1b\\[0m\\n$",
         "^\\*\\*\\*\\*\\* Suggested tool call \\((call_[a-zA-Z0-9]+)\\): ([a-zA-Z0-9_]+) \\*\\*\\*\\*\\*\\n$",
     ),
-    "stars": ("^\\x1b\\[32m(\\*{80}\\*+)\\x1b\\[0m\n$", "^(\\*{80}\\*+)\\n$"),
+    "stars": ("^\\x1b\\[32m(\\*{69}\\*+)\\x1b\\[0m\n$", "^(\\*{69}\\*+)\\n$"),
     "function_call_execution": (
         "^\\x1b\\[35m\\n>>>>>>>> EXECUTING FUNCTION ([a-zA-Z_]+)...\\x1b\\[0m\\n$",
         "^\\n>>>>>>>> EXECUTING FUNCTION ([a-zA-Z_]+)...\\n$",
@@ -124,9 +124,14 @@ class CurrentMessage:
             pass
         else:
             if self.type == "suggested_function_call":
-                # logger.info("CurrentMessage.process_chunk(): parsing arguments")
-                arguments_json: str = _findall("arguments", chunk)  # type: ignore[assignment]
-                self.arguments = json.loads(arguments_json)
+                if _match("arguments", chunk):
+                    # logger.info("CurrentMessage.process_chunk(): parsing arguments")
+                    arguments_json: str = _findall("arguments", chunk)  # type: ignore[assignment]
+                    self.arguments = json.loads(arguments_json)
+                else:
+                    logger.warning(
+                        f"CurrentMessage.process_chunk(): unexpected chunk: {chunk=}, {self=}"
+                    )
             elif self.type == "function_call_execution":
                 # logger.info("CurrentMessage.process_chunk(): parsing retval")
                 self.retval = chunk


### PR DESCRIPTION
# Description

Fixes parsing error caused by variable number of stars outputted by AutoGen IOStream classes

Fixes #200 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (a non-breaking change that resolves an issue)

## Checklist

- [x] My code adheres to the style guidelines of this project (`scripts/lint.sh` shows no errors)
- [x] I have conducted a self-review of my own code
- [ ] I have made the necessary changes to the documentation
- [x] My changes do not generate any new warnings
- [ ] I have added tests to validate the effectiveness of my fix or the functionality of my new feature
- [x] Both new and existing unit tests pass successfully on my local environment by running `scripts/test-cov.sh`
- [x] I have ensured that static analysis tests are passing by running `scripts/static-anaylysis.sh`
- [ ] I have included code examples to illustrate the modifications
